### PR TITLE
fix: title for issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ This is a tool for getting link suggestions while writing READMEs and GitHub Wik
 
 Use this LSP in conjunction with some other Markdown LSP if you want gotoDefinition et.al. This LSP only focuses on adding autocomplete to
 
-* [x] `#` Issues and PRs
-* [x] `[` Public Wiki Pages
-* [x] `:` Organizations / Owners
-* [x] `/` Repositories (yours and the orgs you are part of, no global search yet)
-* [x] `@` Organization Members
+- [x] `#` Issues and PRs
+- [x] `[` Public Wiki Pages
+- [x] `:` Organizations / Owners
+- [x] `/` Repositories (yours and the orgs you are part of, no global search yet)
+- [x] `@` Organization Members
 
 [Issues](https://github.com/github-language-server/github-lsp/issues) and [PRs](https://github.com/github-language-server/github-lsp/pulls) are very welcome!
 
@@ -47,8 +47,8 @@ You can now configure your editor to use this LSP on `stdio`.
 
 ### `#` trigger
 
-[#1](https://github.com/github-language-server/github-lsp/issues/1)
-[#2](https://github.com/github-language-server/github-lsp/issues/2)
+[#1: Example open issue](https://github.com/github-language-server/github-lsp/issues/1)
+[#2: Example closed issue](https://github.com/github-language-server/github-lsp/issues/2)
 
 ### `@` trigger
 

--- a/src/gh/issue.rs
+++ b/src/gh/issue.rs
@@ -25,13 +25,14 @@ impl GetLabel for Issue {
 impl GetEdit for Issue {
     fn get_edit(&self) -> String {
         let id = self.number;
+        let title = &self.title;
         let url = self
             .url
             .to_string()
             .replace("api.", "")
             .replace("repos/", "");
         //TODO: cleanup & consider just printing the full URL and let GitHub format it
-        format!("[#{id}]({url})")
+        format!("[#{id}: {title}]({url})")
     }
 }
 impl GetDetail for Issue {


### PR DESCRIPTION
[#1: Example open issue](https://github.com/github-language-server/github-lsp/issues/1)
[#2: Example closed issue](https://github.com/github-language-server/github-lsp/issues/2)

and not

[#1](https://github.com/github-language-server/github-lsp/issues/1)
[#2](https://github.com/github-language-server/github-lsp/issues/2)
