### PR TITLE
fix: remove email from author label

### DIFF
--- a/src/gh/author.rs
+++ b/src/gh/author.rs
@@ -4,7 +4,7 @@ use super::{GetDetail, GetEdit, GetLabel};
 
 impl GetLabel for Author {
     fn get_label(&self) -> String {
-        format!("{} <{:?}>", self.login, self.email)
+        self.login.to_string()
     }
 }
 impl GetEdit for Author {


### PR DESCRIPTION
Currently authors report as `$username <None>` because the `Option<String>` `email` is not set. This PR removes it from label.